### PR TITLE
Fix site repository link

### DIFF
--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -14,5 +14,5 @@ layout: page
 </div>
 
 </p>
-<p>If there is something you would like to see added to this page, please send us a <a href="//groups.google.com/d/contactowner/lambda-ladies-functional">message</a> or a <a href="//github.com/lambdaladies/lambdaladies.com">pull request</a>.</p>
+<p>If there is something you would like to see added to this page, please send us a <a href="//groups.google.com/d/contactowner/lambda-ladies-functional">message</a> or a <a href="//github.com/lambdaladies/lambdaladies.github.io">pull request</a>.</p>
 

--- a/_site/resources/index.html
+++ b/_site/resources/index.html
@@ -132,7 +132,7 @@
 </div>
 
 </p>
-<p>If there is something you would like to see added to this page, please send us a <a href="//groups.google.com/d/contactowner/lambda-ladies-functional">message</a> or a <a href="//github.com/lambdaladies/lambdaladies.com">pull request</a>.</p>
+<p>If there is something you would like to see added to this page, please send us a <a href="//groups.google.com/d/contactowner/lambda-ladies-functional">message</a> or a <a href="//github.com/lambdaladies/lambdaladies.github.io">pull request</a>.</p>
 
 
     

--- a/_site/talks/index.html
+++ b/_site/talks/index.html
@@ -59,7 +59,7 @@
 </ul>
 
 <p></p>
-If there is something you would like to see added to this page, please send us a <a href="https://groups.google.com/d/contactowner/lambda-ladies-functional">message</a> or a <a href="https://github.com/lambdaladies/lambdaladies.com">pull request</a>.</p>
+If there is something you would like to see added to this page, please send us a <a href="https://groups.google.com/d/contactowner/lambda-ladies-functional">message</a> or a <a href="https://github.com/lambdaladies/lambdaladies.github.io">pull request</a>.</p>
 
     
 <div class="social">

--- a/talks.markdown
+++ b/talks.markdown
@@ -15,5 +15,5 @@ Several Lambda Ladies have given presentations about functional programming. Her
 * Why Haskell? by [Susan Potter](https://twitter.com/susanpotter) ([slides](http://www.slideshare.net/mbbx6spp/why-haskell))
 
 </p>
-If there is something you would like to see added to this page, please send us a [message](https://groups.google.com/d/contactowner/lambda-ladies-functional) or a [pull request](https://github.com/lambdaladies/lambdaladies.com).
+If there is something you would like to see added to this page, please send us a [message](https://groups.google.com/d/contactowner/lambda-ladies-functional) or a [pull request](https://github.com/lambdaladies/lambdaladies.github.io).
 


### PR DESCRIPTION
Several pages link to your old repo (`lambdaladies/lambdaladies.com`), which leads to a 404 page. This updates them to use the new repo (`lambdaladies/lambdaladies.github.io`).

I just used `sed` to fix the links across the project. If you think the repo might change again, it might be worth putting this in a variable somewhere. I don't know offhand how to do that with Jekyll, so I thought I'd just submit this as-is.